### PR TITLE
feat(auth): Add change password and refine reset password APIs

### DIFF
--- a/app/Http/Requests/Api/V1/Auth/ChangePasswordRequest.php
+++ b/app/Http/Requests/Api/V1/Auth/ChangePasswordRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Api\V1\Auth;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Password;
 
-class ResetPasswordRequest extends FormRequest
+class ChangePasswordRequest extends FormRequest
 {
 
     /**
@@ -24,16 +24,12 @@ class ResetPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email'    => ['required', 'email'],
-            'token'    => ['required', 'string'],
-            'password' => [
+            'current_password' => ['required', 'current_password:api'],
+            'new_password'     => [
                 'required',
                 'confirmed',
-                Password::min(8)
-                    ->mixedCase()
-                    ->numbers()
-                    ->symbols()
-                    ->uncompromised(),
+                'different:current_password',
+                Password::min(8)->mixedCase()->numbers()->symbols()->uncompromised(),
             ],
         ];
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,4 +24,9 @@ Route::prefix('/v1/auth')->group(function () {
 
     Route::post('/reset-password', [AuthController::class, 'resetPassword'])
         ->middleware('throttle:5,60');
+
+    Route::middleware('auth:api')->group(function () {
+        Route::post('/change-password', [AuthController::class, 'changePassword'])
+            ->middleware('throttle:10,60'); // [C07]
+    });
 });


### PR DESCRIPTION
Implement a new, authenticated endpoint for users to change their own password. Refine the existing password reset flow with stricter validation and more specific error responses.

Change Password (New Feature):
- Create a protected `POST /api/v1/auth/change-password` endpoint that requires JWT authentication.
- Add `ChangePasswordRequest` to validate `current_password` against the database.
- Enforce strong password policy for `new_password` using Laravel's built-in validation rules (mixed case, numbers, symbols).
- On success, invalidate the current token to enhance security and return a 204 No Content response.

Reset Password (Refinements):
- Update `ResetPasswordRequest` to use the strong password policy rules.
- Refine the `resetPassword` controller logic to return more specific HTTP status codes:
  - `404 Not Found` for invalid token/email.
  - `410 Gone` for expired or already used tokens.
- Change the success response to `204 No Content` to align with API best practices for this action.